### PR TITLE
Adding the global tag

### DIFF
--- a/dunstrc
+++ b/dunstrc
@@ -1,5 +1,7 @@
+[global]
 frame_color = "#96CDFB"
 separator_color= frame
+font = JetBrains Mono Nerd Font 10
 
 [urgency_low]
 background = "#1E1E2E"


### PR DESCRIPTION
When not using the global tag, you get an error which won't render the config file correctly such as the separator color and frame color. Also, adding JetBrains Mono Nerd Font as the default font so icons render correctly, that is if added.